### PR TITLE
fix: download full-resolution image instead of square crop

### DIFF
--- a/src/js/post.js
+++ b/src/js/post.js
@@ -78,19 +78,10 @@ async function downloadPostPhotos() {
     function extractMediaData(item) {
         const isVideo = item['media_type'] !== 1;
         const mediaItems = isVideo ? item['video_versions'] : item['image_versions2'].candidates;
-        // Instagram includes center-cropped variants (often square) in candidates.
-        // Keep only the ones matching the original aspect ratio so we don't pick a crop.
-        const originalRatio = item['original_width'] / item['original_height'];
-        const uncropped = mediaItems.filter(
-            (candidate) => Math.abs(candidate.width / candidate.height - originalRatio) < 0.01,
-        );
-        const candidates = uncropped.length ? uncropped : mediaItems;
-        // Pick by area (width * height), not width alone, to avoid ties between a
-        // full image and a same-width crop.
-        const largestMediaItem = candidates.reduce((accumulator, currentValue) => {
-            if (accumulator.width * accumulator.height >= currentValue.width * currentValue.height) return accumulator;
+        const largestMediaItem = mediaItems.reduce((accumulator, currentValue) => {
+            if (accumulator.width * accumulator.height > currentValue.width * currentValue.height) return accumulator;
             return currentValue;
-        }, candidates[0]);
+        }, mediaItems[0]);
         const media = {
             url: largestMediaItem.url,
             isVideo,

--- a/src/js/post.js
+++ b/src/js/post.js
@@ -78,10 +78,19 @@ async function downloadPostPhotos() {
     function extractMediaData(item) {
         const isVideo = item['media_type'] !== 1;
         const mediaItems = isVideo ? item['video_versions'] : item['image_versions2'].candidates;
-        const largestMediaItem = mediaItems.reduce((accumulator, currentValue) => {
-            if (accumulator.width > currentValue.width) return accumulator;
+        // Instagram includes center-cropped variants (often square) in candidates.
+        // Keep only the ones matching the original aspect ratio so we don't pick a crop.
+        const originalRatio = item['original_width'] / item['original_height'];
+        const uncropped = mediaItems.filter(
+            (candidate) => Math.abs(candidate.width / candidate.height - originalRatio) < 0.01,
+        );
+        const candidates = uncropped.length ? uncropped : mediaItems;
+        // Pick by area (width * height), not width alone, to avoid ties between a
+        // full image and a same-width crop.
+        const largestMediaItem = candidates.reduce((accumulator, currentValue) => {
+            if (accumulator.width * accumulator.height >= currentValue.width * currentValue.height) return accumulator;
             return currentValue;
-        }, mediaItems[0]);
+        }, candidates[0]);
         const media = {
             url: largestMediaItem.url,
             isVideo,


### PR DESCRIPTION
## Problem

When downloading a post, images are sometimes saved **cropped to a square** instead of in their original aspect ratio.

Instagram's `image_versions2.candidates` array contains, besides the full-aspect image at several sizes, **center-cropped variants** (typically a 1:1 square used for the profile grid). For a portrait image the array looks like:

```
1080x1350  <- full (original ratio)
720x900
...
1080x1080  <- square crop, SAME width as the full one
750x750
...
```

`extractMediaData` selected the largest candidate **by width only**:

```js
const largestMediaItem = mediaItems.reduce((accumulator, currentValue) => {
    if (accumulator.width > currentValue.width) return accumulator;
    return currentValue;
}, mediaItems[0]);
```

When the square crop shares the maximum width (`1080x1080` vs `1080x1350`), `accumulator.width > currentValue.width` is `false` on the tie, so the reducer keeps the **later** element — the crop. The downloaded image ends up cut.

## Fix

Filter candidates to those matching the original aspect ratio (`original_width` / `original_height`), then select by **area** instead of width alone. Falls back to all candidates if none match, so it never breaks.

## Verification

Tested against a real 12-image carousel post (`https://www.instagram.com/p/DaA1Euamc9o/`):

| Item | original | before (width-only) | after (this PR) |
|------|----------|---------------------|-----------------|
| #0–#3, #5, #7–#11 | 1080x1350 | **1080x1080 (crop)** | 1080x1350 |
| #4, #6 | 2160x2700 | 2160x2700 (ok) | 2160x2700 (ok) |

10 of 12 images were being cropped; all are now full-resolution, with no regression on the two that were already correct (their original is wider than 1080, so no same-width square crop exists to cause the tie).
